### PR TITLE
Amend privacy policy embed name

### DIFF
--- a/cogs/seng_info.py
+++ b/cogs/seng_info.py
@@ -19,7 +19,7 @@ class PrivacyPolicy(commands.Cog):
             description=priv_pol_text,
             colour=discord.Color.teal()
         )
-        await ctx.send(embed=priv_pol)
+        await ctx.send(embed=priv_pol_embed)
 
     @commands.command()
     async def source_code(self, ctx):


### PR DESCRIPTION
The embed is called priv_pol_embed, but I had referenced it later as
priv_pol_embed, which was causing the privacy policy not to send.

Fixes #13 