### PR TITLE
Moved bot.processes underneath the instantiation of bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,12 +15,12 @@ from cogs.seng_info import PrivacyPolicy
 intents = discord.Intents.default()
 intents.members = True
 
+bot = commands.Bot(command_prefix='$')
+
 # Seng should keep track of which users are using which of Seng's processes,
 # as some processes may only be 'user-safe' with a single user. We track this
 # dictionary of 'task: user_id' in a bot constant called 'processes'.
 bot.processes = {}
-
-bot = commands.Bot(command_prefix='$')
 
 @bot.event
 async def on_ready():


### PR DESCRIPTION
Closes #21 

Moved `bot.processes` and its associated comments underneath the instantiation of `bot` 